### PR TITLE
Only highlight trailing whitespace if it is preceded by...

### DIFF
--- a/Syntaxes/Trailing Whitespace.tmLanguage
+++ b/Syntaxes/Trailing Whitespace.tmLanguage
@@ -11,10 +11,16 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.whitespace.trailing</string>
+				</dict>
+			</dict>
 			<key>match</key>
-			<string>([^\S\n\f\r]+)$</string>
-			<key>name</key>
-			<string>invalid.illegal.whitespace.trailing</string>
+			<string>((\S)([^\S\n\f\r]+)$)</string>
 		</dict>
 	</array>
 	<key>uuid</key>


### PR DESCRIPTION
... a non-whitespace character.

Fixes https://github.com/mads379/Whitespace.tmbundle/issues/7
